### PR TITLE
Can Reconfigure RavenLog

### DIFF
--- a/HEInventions.Logging/Properties/AssemblyInfo.cs
+++ b/HEInventions.Logging/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/HEInventions.Logging/RavenLog.cs
+++ b/HEInventions.Logging/RavenLog.cs
@@ -1,13 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using SharpRaven;
 using SharpRaven.Data;
-using System.Collections.Specialized;
-using Newtonsoft.Json.Linq;
-using System.IO;
 
 namespace HEInventions.Logging
 {
@@ -65,15 +59,13 @@ namespace HEInventions.Logging
         #region RavenLog Configuration.
         /// <summary>
         /// Configures RavenLog and creates a new instance by setting the Sentry DSN, a severity threshold, and optional
-        /// additional tags.
+        /// additional tags. If an instance already exists, it will overwrite it
         /// </summary>
         /// <param name="sentryDSN">The Sentry server to post events to.</param>
         /// <param name="errorThreshold">The severity threshold - all errors equal to or above this will be logged.</param>
         /// <param name="extraTags">Additional tags that are useful to send up with a Sentry event.</param>
         public static void Configure(string sentryDSN, string errorThreshold, Dictionary<string, string> extraTags = null)
         {
-            if (_Instance != null)
-                throw new InvalidOperationException("RavenLog is already configured.");
 
             Instance = new RavenLog()
             {


### PR DESCRIPTION
This will allow RavenLog to be reconfigured.

For example, the use case is:

```
RavenLog.Configure(DSN, "Error");
Settings.Load()
RavenLog.Configure(DSN, "Error", Settings.ToDict());
```

The first configure covers all settings loading and means you are not uncovered at a critical point in application load.